### PR TITLE
Remove unused import so MCU-API builds without JavaFX

### DIFF
--- a/src/main/java/org/mcupdater/model/Module.java
+++ b/src/main/java/org/mcupdater/model/Module.java
@@ -1,6 +1,5 @@
 package org.mcupdater.model;
 
-import javafx.collections.ObservableList;
 import org.mcupdater.downloadlib.Downloadable;
 import org.mcupdater.util.CurseModCache;
 import org.mcupdater.util.MCUpdater;


### PR DESCRIPTION
What it says on the tin. `javafx.collections.ObservableList` is not used in this class