### PR TITLE
Split library name on every colon, not only the first two

### DIFF
--- a/src/main/java/org/mcupdater/mojang/Library.java
+++ b/src/main/java/org/mcupdater/mojang/Library.java
@@ -38,7 +38,7 @@ public class Library {
 	}
 
 	public String getLibraryPath(String classifier) {
-		String[] parts = this.name.split(":",3);
+		String[] parts = this.name.split(":",0);
 		return String.format("%s/%s/%s/%s-%s%s.jar", parts[0].replaceAll("\\.", "/"),parts[1],parts[2],parts[1],parts[2], (classifier == null ? "" : "-" + classifier)).replace("${arch}", System.getProperty("sun.arch.data.model"));
 	}
 	
@@ -55,7 +55,7 @@ public class Library {
 	
 	public String getFilename() {
 		String result;
-		String[] parts = this.name.split(":",3);
+		String[] parts = this.name.split(":",0);
 		if (this.natives != null) {
 			if (this.natives.containsKey(OperatingSystem.getCurrentPlatform())) {
 				result = String.format("%s/%s/%s/%s-%s-%s.jar", parts[0].replaceAll("\\.", "/"),parts[1],parts[2],parts[1], parts[2], natives.get(OperatingSystem.getCurrentPlatform()));


### PR DESCRIPTION
Manifest for 1.19.2 contains names with 4 colon-separated entries for some libraries (e.g., "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos"). This currently breaks downloading and classpath generation, making MCUpdater unable to launch minecraft.